### PR TITLE
Flatpak manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,12 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+#flatpak
+.flatpak/
+.flatpak-builder
+repo/
+build-dir/
+
+#vscode
+.vscode/

--- a/flatpak/com.github.upscayl.upscayl.json
+++ b/flatpak/com.github.upscayl.upscayl.json
@@ -1,0 +1,72 @@
+{
+  "app-id": "com.github.upscayl.upscayl",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "22.08",
+  "sdk": "org.freedesktop.Sdk",
+  "base": "org.electronjs.Electron2.BaseApp",
+  "base-version": "22.08",
+  "command": "upscayl-wrapper",
+  "separate-locales": false,
+  "finish-args": [
+    "--share=ipc",
+    "--socket=x11",
+    "--device=dri",
+    "--filesystem=home"
+  ],
+  "modules": [
+    {
+      "name": "zypak",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/refi64/zypak",
+          "tag": "v2022.04"
+        }
+      ]
+    },
+    {
+      "name": "upscayl",
+      "buildsystem": "simple",
+      "cleanup": [
+        "upscayl-1.5.5.zip"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "only-arches": [
+            "x86_64"
+          ],
+          "url": "https://github.com/JanDeDinoMan/upscayl/releases/download/v1.5.5/upscayl-1.5.5.zip",
+          "sha256": "0e57b3cbb96299fac6beea185ffdf2f105d3258ac6081bd1f3c408912541dacc"
+        },
+        {
+          "type": "file",
+          "path": "com.github.upscayl.upscayl.metainfo.xml"
+        },
+        {
+          "type": "file",
+          "path": "../main/build/icon.png"
+        },
+        {
+          "type": "script",
+          "dest-filename": "upscayl-wrapper",
+          "commands": [
+            "zypak-wrapper /app/upscayl/upscayl"
+          ]
+        }
+      ],
+      "build-commands": [
+        "install -d /app/upscayl",
+        "unzip upscayl-1.5.5 -d /app/upscayl",
+        "install upscayl-wrapper /app/bin/",
+        "install -d /app/share/icons/hicolor/512x512/apps/",
+        "install icon.png /app/share/icons/hicolor/512x512/apps/com.github.upscayl.upscayl.png",
+        "install -d /app/share/applications",
+        "touch com.github.upscayl.upscayl.desktop",
+        "install -Dp -m644 com.github.upscayl.upscayl.metainfo.xml /app/share/metainfo/com.github.upscayl.upscayl.metainfo.xml",
+        "install -m644 com.github.upscayl.upscayl.desktop /app/share/applications/com.github.upscayl.upscayl.desktop",
+        "desktop-file-edit --set-key=Exec --set-value='upscayl-wrapper %U' --set-key=Icon --set-value='com.github.upscayl.upscayl' --set-key=Comment --set-value='Upscale Images' --set-key=Name --set-value='Upscayl' --set-key=StartupNotify --set-value='false' --set-key=Categories --set-value='ImageProcessing;RasterGraphics;Graphics;' --set-key=Type --set-value='Application' /app/share/applications/com.github.upscayl.upscayl.desktop"
+      ]
+    }
+  ]
+}

--- a/flatpak/com.github.upscayl.upscayl.metainfo.xml
+++ b/flatpak/com.github.upscayl.upscayl.metainfo.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="desktop">
+    <id>com.github.upscayl.upscayl</id>
+    <name>Upscayl</name>
+    <summary>Free and Open Source AI Image Upscaler</summary>
+    <developer_name>Nayam Amarshe</developer_name>
+    <launchable type="desktop-id">com.github.upscayl.upscayl.desktop</launchable>
+    <metadata_license>FSFAP</metadata_license>
+    <project_license>AGPL-3.0</project_license>
+    <description>
+        <p>Free and Open Source AI Image Upscaler</p>
+    </description>
+    <url type="homepage">https://github.com/upscayl/upscayl/</url>
+    <url type="bugtracker">https://github.com/upscayl/upscayl/issues</url>
+    <categories>
+        <category>Graphics</category>
+        <category>RasterGraphics</category>
+        <category>ImageProcessing</category>
+    </categories>
+    <content_rating type="oars-1.1" />
+    <keywords>
+        <keyword>upscale</keyword>
+    </keywords>
+    <translation type="gettext">Upscayl</translation>
+</component>

--- a/main/index.js
+++ b/main/index.js
@@ -66,6 +66,7 @@ app.on("ready", async () => {
 
   mainWindow.once("ready-to-show", () => {
     mainWindow.show();
+    mainWindow.webContents.setZoomFactor(1)
   });
 
   if (!isDev) {

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,5 @@
 module.exports = {
-    experimental: {
-        images: {
-            unoptimized: true
-        }
+    images: {
+        unoptimized: true
     }
 }

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "autoprefixer": "^10.4.8",
     "electron": "^20.0.2",
     "electron-builder": "^23.3.3",
-    "next": "^12.2.5",
+    "next": "^12.3.1",
     "postcss": "^8.4.16",
     "prettier": "^2.7.1",
     "prettier-plugin-tailwindcss": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dist": "npm run build && DEBUG=* electron-builder",
     "dist:appimage": "npm run build && DEBUG=* electron-builder build -l AppImage",
     "dist:flatpak": "npm run build && DEBUG=* electron-builder build -l flatpak",
+    "dist:zip": "npm run build && DEBUG=* electron-builder build -l zip",
     "dist:dmg": "npm run build && DEBUG=* electron-builder build -m dmg",
     "dist:msi": "npm run build && DEBUG=* electron-builder build -w nsis",
     "dist:pkg": "npm run build && DEBUG=* electron-builder build -m pkg",
@@ -101,7 +102,8 @@
       ],
       "target": [
         "AppImage",
-        "flatpak"
+        "flatpak",
+        "zip"
       ],
       "category": "Graphics;2DGraphics;RasterGraphics;ImageProcessing;",
       "icon": "main/build/icon.png"


### PR DESCRIPTION
Hello I thought I could maybe be of some help by providing an Flatpak manifest that could be used on Flathub.

It uses prebuild archives so this is really only for Flathub and not local builds. For now the archive url uses a placeholder for testing purposes. Future releases would need to provide the actual zip.

The manifest can be tested locally with the following commands:

```sh
flatpak-builder --user --repo=repo --install-deps-from=flathub --force-clean build-dir flatpak/com.github.upscayl.upscayl.json
flatpak --user remote-add --no-gpg-verify upscayl-repo repo
flatpak install com.github.upscayl.upscayl -y
flatpak run com.github.upscayl.upscayl
```
This can be used to fix #21 