### PR TITLE
Add a workaround for signing issues on Apple chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,7 @@ You can also download the flatpak version and double click the flatpak file to i
 
 3. Double click dmg, drag Upscayl icon into Applications folder.
 
-> **Note** <br />
-> If you have an Apple chip, you might get an error when opening the application due to it not being signed. To work around this, run the following command in your terminal (just this once):
->
-> ```
-> sudo xattr -r -d com.apple.quarantine /Applications/Upscayl.app
-> ```
-
+If you encounter an error with opening the application, try Ctrl+Clicking/Right-clicking the app and clicking open. In the popup that opens, also click open.
 ### Windows 🐌
 
 1. Go to [releases section](https://github.com/TGS963/upscayl/releases/latest)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ You can also download the flatpak version and double click the flatpak file to i
 
 3. Double click dmg, drag Upscayl icon into Applications folder.
 
+> **Note** <br />
+> If you have an Apple chip, you might get an error when opening the application due to it not being signed. To work around this, run the following command in your terminal (just this once):
+>
+> ```
+> sudo xattr -r -d com.apple.quarantine /Applications/Upscayl.app
+> ```
+
 ### Windows 🐌
 
 1. Go to [releases section](https://github.com/TGS963/upscayl/releases/latest)


### PR DESCRIPTION
Reference: https://hovancik.net/stretchly/downloads/

Stretchly is an Electron application that also has problems with signing, and they list this workaround in their installation instructions

Related to #34 