### PR TITLE
disallow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
note that blank issues can still be created by, for example, going to https://github.com/aaronliu0130/upscayl/new . This merely hides the message "Don’t see your issue here? Open a blank issue. " in the template chooser