### PR TITLE
Make "STOP" button have the danger class

### DIFF
--- a/renderer/components/upscayl-tab/view/ProgressBar.tsx
+++ b/renderer/components/upscayl-tab/view/ProgressBar.tsx
@@ -21,7 +21,7 @@ function ProgressBar({
         <p className="rounded-full bg-base-300 px-2 py-1 text-sm font-medium">
           Doing the Upscayl magic...
         </p>
-        <button onClick={stopHandler} className="btn-primary btn">
+        <button onClick={stopHandler} className="btn-danger btn">
           STOP
         </button>
       </div>


### PR DESCRIPTION
While In the default theme this makes the button look red, in Upscayl's default light theme it looks silver:
![image](https://github.com/upscayl/upscayl/assets/11874211/207f741b-4118-44c4-bb02-d4e2aea9d4b4)