### PR TITLE
Upgrade `react-compare-slider` for keyboard controls and improved a11y

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upscayl",
-  "version": "2.9.5",
+  "version": "2.9.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upscayl",
-      "version": "2.9.5",
+      "version": "2.9.8",
       "license": "AGPL-3.0",
       "dependencies": {
         "dotenv": "^16.3.1",
@@ -18,7 +18,7 @@
         "firebase": "^10.3.0",
         "gray-matter": "^4.0.3",
         "jotai": "^2.2.2",
-        "react-compare-slider": "^2.2.0",
+        "react-compare-slider": "^3.0.1",
         "react-markdown": "^9.0.1",
         "react-select": "^5.7.4",
         "react-tooltip": "^5.18.1",
@@ -6454,9 +6454,12 @@
       }
     },
     "node_modules/react-compare-slider": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-compare-slider/-/react-compare-slider-2.2.0.tgz",
-      "integrity": "sha512-I77xqulpoibZ9eqjn5wjpZL5IRpUZYcUlde70YaJ+MORGbUThrjTlHKl/UeGyCIPUWtPID5f5/zK9Q+1ovQLeA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-compare-slider/-/react-compare-slider-3.0.1.tgz",
+      "integrity": "sha512-+y7x30GCMmk7tl0lBgWRdEjOEMSD4tgPPVyQfBjN6LxU0gdYc4n0+XvnwTJQWwJPd+t2JuniYi1ZxczFVf4fnw==",
+      "engines": {
+        "node": ">=16.9.0"
+      },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
@@ -12586,9 +12589,9 @@
       }
     },
     "react-compare-slider": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-compare-slider/-/react-compare-slider-2.2.0.tgz",
-      "integrity": "sha512-I77xqulpoibZ9eqjn5wjpZL5IRpUZYcUlde70YaJ+MORGbUThrjTlHKl/UeGyCIPUWtPID5f5/zK9Q+1ovQLeA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-compare-slider/-/react-compare-slider-3.0.1.tgz",
+      "integrity": "sha512-+y7x30GCMmk7tl0lBgWRdEjOEMSD4tgPPVyQfBjN6LxU0gdYc4n0+XvnwTJQWwJPd+t2JuniYi1ZxczFVf4fnw==",
       "requires": {}
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "firebase": "^10.3.0",
     "gray-matter": "^4.0.3",
     "jotai": "^2.2.2",
-    "react-compare-slider": "^2.2.0",
+    "react-compare-slider": "^3.0.1",
     "react-markdown": "^9.0.1",
     "react-select": "^5.7.4",
     "react-tooltip": "^5.18.1",


### PR DESCRIPTION
Hi, this is a really small PR to upgrade the slider lib. The latest version adds keyboard functionality, much improved accessibility [and a fair few other improvements](https://github.com/nerdyman/react-compare-slider/releases/tag/v3.0.0). The API is the same as before so there are no actual code changes required.