### PR TITLE
[WIP] Initial notification icon support

### DIFF
--- a/electron/utils/show-notification.ts
+++ b/electron/utils/show-notification.ts
@@ -1,6 +1,6 @@
 import { Notification } from "electron/main";
 import { turnOffNotifications } from "./config-variables";
-import * as fs from 'fs';
+import fs from 'fs';
 
 export default function showNotification(title: string, body: string) {
   if (turnOffNotifications) return;

--- a/electron/utils/show-notification.ts
+++ b/electron/utils/show-notification.ts
@@ -1,11 +1,31 @@
 import { Notification } from "electron/main";
 import { turnOffNotifications } from "./config-variables";
+import * as fs from 'fs';
 
 export default function showNotification(title: string, body: string) {
   if (turnOffNotifications) return;
-  new Notification({
+
+  const iconPaths = [
+    "/app/share/icons/hicolor/128x128/apps/org.upscayl.Upscayl.png", // flatpak icon
+    "__appImage-x64/usr/share/icons/hicolor/128x128/apps/upscayl.png", // appimage icon
+    "/usr/share/icons/hicolor/128x128/apps/upscayl.png", // deb & rpm icon
+    "resources/128x128.png", // win icon
+    "build/icon.icns", // mac icon
+  ];
+  
+  // Find the first available icon path
+  let iconPath = '';
+  for (const path of iconPaths) {
+    if (fs.existsSync(path)) {
+      iconPath = path;
+      break;
+    }
+  }
+
+  const notification = new Notification({
     title,
     body,
     closeButtonText: "Close",
+    icon: iconPath,
   }).show();
 }


### PR DESCRIPTION
As icon locations are platform dependent, iterate through paths & add to notification util. 
Confirmed working well for linux(deb/rpm), AppImage & Windows platforms.

Todo:
- Confirm mac & flatpak icon paths are correct (i'm unable to test)
@aaronliu0130 appreciate if you're able to test. 

**Before and after shots:**

Linux notifications:
![upscayl-notif-linux](https://github.com/upscayl/upscayl/assets/127086564/4f98257f-0a1c-4ce1-a346-914b1e46fd0c)
(bottom before, top after)

Windows:
![upscayl-win-notif](https://github.com/upscayl/upscayl/assets/127086564/1aa5ffb6-c907-4493-97de-ee1b99a627e9)


Win.