### PR TITLE
Update image-upscayl.ts

### DIFF
--- a/electron/commands/image-upscayl.ts
+++ b/electron/commands/image-upscayl.ts
@@ -59,8 +59,8 @@ const imageUpscayl = async (event, payload: ImageUpscaylPayload) => {
 
   // Check if windows can write the new filename to the file system
   if (outFile.length >= 255) {
-    logit(" Filename is too long for windows file system.")
-    mainWindow.webContents.send(COMMAND.UPSCAYL_ERROR, data.toString());
+    logit("Filename too long for Windows.");
+    mainWindow.webContents.send(COMMAND.UPSCAYL_ERROR, "The filename exceeds the maximum path length allowed by Windows. Please shorten the filename or choose a different save location.");
   }
   
   // UPSCALE

--- a/electron/commands/image-upscayl.ts
+++ b/electron/commands/image-upscayl.ts
@@ -57,6 +57,12 @@ const imageUpscayl = async (event, payload: ImageUpscaylPayload) => {
 
   const isDefaultModel = DEFAULT_MODELS.includes(model);
 
+  // Check if windows can write the new filename to the file system
+  if (outFile.length >= 255) {
+    logit(" Filename is too long for windows file system.")
+    mainWindow.webContents.send(COMMAND.UPSCAYL_ERROR, data.toString());
+  }
+  
   // UPSCALE
   if (fs.existsSync(outFile) && !overwrite) {
     // If already upscayled, just output that file


### PR DESCRIPTION
Added check for exceeding MAX_PATH limit in windows.
This is not a fix, just gives users some idea why they can't save the files. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added a check to handle excessively long filenames, ensuring compatibility with Windows file system limits. An error message will be displayed if the filename exceeds the permissible length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->