### PR TITLE
Compare different models feature

### DIFF
--- a/electron/commands/double-upscayl.ts
+++ b/electron/commands/double-upscayl.ts
@@ -121,7 +121,10 @@ const doubleUpscayl = async (event, payload: DoubleUpscaylPayload) => {
       logit("💯 Done upscaling");
 
       mainWindow.setProgressBar(-1);
-      mainWindow.webContents.send(COMMAND.DOUBLE_UPSCAYL_DONE, outFile);
+      mainWindow.webContents.send(COMMAND.DOUBLE_UPSCAYL_DONE, {
+        fileName: fullfileName,
+        data: outFile,
+      });
       showNotification("Upscayled", "Image upscayled successfully!");
     }
   };

--- a/electron/commands/image-upscayl.ts
+++ b/electron/commands/image-upscayl.ts
@@ -60,14 +60,20 @@ const imageUpscayl = async (event, payload: ImageUpscaylPayload) => {
   // Check if windows can write the new filename to the file system
   if (outFile.length >= 255) {
     logit("Filename too long for Windows.");
-    mainWindow.webContents.send(COMMAND.UPSCAYL_ERROR, "The filename exceeds the maximum path length allowed by Windows. Please shorten the filename or choose a different save location.");
+    mainWindow.webContents.send(
+      COMMAND.UPSCAYL_ERROR,
+      "The filename exceeds the maximum path length allowed by Windows. Please shorten the filename or choose a different save location.",
+    );
   }
-  
+
   // UPSCALE
   if (fs.existsSync(outFile) && !overwrite) {
     // If already upscayled, just output that file
     logit("✅ Already upscayled at: ", outFile);
-    mainWindow.webContents.send(COMMAND.UPSCAYL_DONE, outFile);
+    mainWindow.webContents.send(COMMAND.UPSCAYL_DONE, {
+      fileName: fileNameWithExt,
+      data: outFile,
+    });
   } else {
     logit(
       "✅ Upscayl Variables: ",
@@ -137,7 +143,10 @@ const imageUpscayl = async (event, payload: ImageUpscaylPayload) => {
         // Free up memory
         upscayl.kill();
         mainWindow.setProgressBar(-1);
-        mainWindow.webContents.send(COMMAND.UPSCAYL_DONE, outFile);
+        mainWindow.webContents.send(COMMAND.UPSCAYL_DONE, {
+          fileName: fileNameWithExt,
+          data: outFile,
+        });
         showNotification("Upscayl", "Image upscayled successfully!");
       }
     };

--- a/renderer/components/upscayl-tab/view/ImageOptions.tsx
+++ b/renderer/components/upscayl-tab/view/ImageOptions.tsx
@@ -4,17 +4,35 @@ import { cn } from "@/lib/utils";
 import { useAtom, useAtomValue } from "jotai";
 import { WrenchIcon } from "lucide-react";
 import { useEffect, useState } from "react";
+import PreviousRenders from "./PreviousRenders";
 
 const ImageOptions = ({
   zoomAmount,
   setZoomAmount,
   resetImagePaths,
   hideZoomOptions,
+  upImgPath,
+  upscaylHandler,
+  srcFilename,
+  setUpscaledImagePath,
+  outputPath,
+  handleUpImgPathLog,
 }: {
   zoomAmount: string;
   setZoomAmount: (arg: any) => void;
   resetImagePaths: () => void;
   hideZoomOptions?: boolean;
+  upImgPath?: any[];
+  upscaylHandler?: () => Promise<void>;
+  srcFilename?: string;
+  setUpscaledImagePath?: (arg: any) => void;
+  outputPath?: string;
+  handleUpImgPathLog?: (
+    srcFilename: string,
+    datafullPath: string,
+    typeEvent: string,
+    isDoubleUpscale: boolean,
+  ) => Promise<void>;
 }) => {
   const [openSidebar, setOpenSidebar] = useState(false);
   const [viewType, setViewType] = useAtom(viewTypeAtom);
@@ -109,6 +127,16 @@ const ImageOptions = ({
           />
         </div>
       </div>
+      <div className="flex flex-col justify-center gap-2 overflow-auto p-5">
+        <PreviousRenders
+          lstPath={upImgPath}
+          upscaylHandler={upscaylHandler}
+          srcFilename={srcFilename}
+          setUpscaledImagePath={setUpscaledImagePath}
+          outputPath={outputPath}
+          handleUpImgPathLog={handleUpImgPathLog}
+        />
+      </div>      
     </div>
   );
 };

--- a/renderer/components/upscayl-tab/view/PreviousRenders.tsx
+++ b/renderer/components/upscayl-tab/view/PreviousRenders.tsx
@@ -1,0 +1,128 @@
+import { useAtomValue } from "jotai";
+import { translationAtom } from "@/atoms/translations-atom";
+
+const PreviousRenders = ({
+  lstPath,
+  upscaylHandler,
+  srcFilename,
+  setUpscaledImagePath,
+  outputPath,
+  handleUpImgPathLog,
+}: {
+  lstPath: any[];
+  upscaylHandler: () => Promise<void>;
+  srcFilename: string;
+  setUpscaledImagePath: (arg: any) => void;
+  outputPath: string;
+  handleUpImgPathLog?: (
+    srcFilename: string,
+    datafullPath: string,
+    typeEvent: string,
+    isDoubleUpscale: boolean,
+  ) => Promise<void>;
+}) => {
+  const t = useAtomValue(translationAtom);
+
+  // retrieve mouse hover direction : https://freelance-drupal.com/en/blog/direction-aware-hover-effect-in-pure-css3-and-javascript
+  const getHoverDirection = function (event) {
+    var directions = ["top", "right", "bottom", "left"];
+    var item = event.currentTarget;
+
+    // Width and height of current item.
+    var w = item.offsetWidth;
+    var h = item.offsetHeight;
+
+    // Calculate the x/y value of the pointer entering/exiting, relative to the center of the item.
+    // Scale (sort of normalize) the coordinate on smallest side to the scale of the longest.
+    var x =
+      (event.clientX - item.getBoundingClientRect().left - w / 2) *
+      (w > h ? h / w : 1);
+    var y =
+      (event.clientY - item.getBoundingClientRect().top - h / 2) *
+      (h > w ? w / h : 1);
+
+    // Calculate the angle to the center the pointer entered/exited
+    // and convert to clockwise format (top/right/bottom/left = 0/1/2/3).
+    var d = Math.round(Math.atan2(y, x) / 1.57079633 + 5) % 4;
+
+    return directions[d];
+  };
+
+  return (
+    <>
+      {lstPath && lstPath.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <p className="text-sm font-medium">{t("APP.PREVRENDER.TITLE")}</p>
+        </div>
+      )}
+      {lstPath &&
+        lstPath.map((path) => (
+          <span
+            id="badge-dismiss-dark"
+            className="btn btn-primary"
+            style={{
+              textAlign: "left",
+            }}
+            onMouseEnter={(e) => {
+              setUpscaledImagePath(outputPath + "/" + path.srcFile);
+              upscaylHandler;
+
+              // Reset hover color
+              let elList: NodeListOf<HTMLElement> = document.querySelectorAll(
+                "#badge-dismiss-dark",
+              );
+              elList.forEach(
+                (el) => (el.style.backgroundColor = "revert-layer"),
+              );
+
+              // Change color on hovering
+              e.currentTarget.style.backgroundColor = "#4F46E5";
+            }}
+            onMouseLeave={(e) => {
+              const direction = getHoverDirection(e);
+              if (direction === "top" || direction === "bottom")
+                // Change color on hovering
+                e.currentTarget.style.backgroundColor = "revert-layer";
+            }}
+          >
+            <span
+              style={{
+                minWidth: "80%",
+                maxWidth: "80%",
+              }}
+            >{`${path.modelUsed}`}</span>
+            <button
+              title={t("APP.PREVRENDER.CLEAR")}
+              type="button"
+              className="ms-2 inline-flex items-center rounded-sm bg-transparent p-1 text-sm text-blue-400 hover:bg-blue-200 hover:text-blue-900 dark:hover:bg-blue-800 dark:hover:text-blue-300"
+              key={path.srcFile}
+              data-dismiss-target="#badge-dismiss-dark"
+              aria-label="Remove"
+              onClick={(e) => {
+                handleUpImgPathLog(srcFilename, path.srcFile, "delete", false);
+              }}
+            >
+              <svg
+                className="h-2 w-2"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 14 14"
+              >
+                <path
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"
+                />
+              </svg>
+              <span className="sr-only">Remove</span>
+            </button>
+          </span>
+        ))}
+    </>
+  );
+};
+
+export default PreviousRenders;

--- a/renderer/locales/en.json
+++ b/renderer/locales/en.json
@@ -137,6 +137,10 @@
       "ZOOM_AMOUNT_TITLE": "Zoom Amount",
       "LENS_SIZE_TITLE": "Lens Size"
     },
+    "PREVRENDER": {
+      "TITLE": "Previous renders",
+      "CLEAR": "Clear"
+    },
     "PROGRESS_BAR": {
       "BATCH_UPSCAYL_IN_PROGRESS_TITLE": "Batch Upscayl In Progress:",
       "IN_PROGRESS_TITLE": "Doing the Upscayl magic...",

--- a/renderer/locales/es.json
+++ b/renderer/locales/es.json
@@ -137,6 +137,10 @@
       "ZOOM_AMOUNT_TITLE": "Cantidad de zoom",
       "LENS_SIZE_TITLE": "Tamaño de lente"
     },
+    "PREVRENDER": {
+      "TITLE": "Previous renders",
+      "CLEAR": "Clear"
+    },   
     "PROGRESS_BAR": {
       "BATCH_UPSCAYL_IN_PROGRESS_TITLE": "Aumento por lotes en progreso:",
       "IN_PROGRESS_TITLE": "Haciendo la magia de Upscayl...",

--- a/renderer/locales/fr.json
+++ b/renderer/locales/fr.json
@@ -137,6 +137,10 @@
       "ZOOM_AMOUNT_TITLE": "Niveau de zoom",
       "LENS_SIZE_TITLE": "Taille de la lentille"
     },
+    "PREVRENDER": {
+      "TITLE": "Previous renders",
+      "CLEAR": "Clear"
+    },
     "PROGRESS_BAR": {
       "BATCH_UPSCAYL_IN_PROGRESS_TITLE": "Suréchantillonnage par lot en cours :",
       "IN_PROGRESS_TITLE": "Faire la magie du suréchantillonnage...",

--- a/renderer/locales/ja.json
+++ b/renderer/locales/ja.json
@@ -137,6 +137,10 @@
       "ZOOM_AMOUNT_TITLE": "ズーム量",
       "LENS_SIZE_TITLE": "レンズサイズ"
     },
+    "PREVRENDER": {
+      "TITLE": "Previous renders",
+      "CLEAR": "Clear"
+    },
     "PROGRESS_BAR": {
       "BATCH_UPSCAYL_IN_PROGRESS_TITLE": "バッチUpscayl進行中：",
       "IN_PROGRESS_TITLE": "Upscaylの魔法をかけています...",

--- a/renderer/locales/ru.json
+++ b/renderer/locales/ru.json
@@ -137,6 +137,10 @@
       "ZOOM_AMOUNT_TITLE": "Увеличение",
       "LENS_SIZE_TITLE": "Размер линзы"
     },
+    "PREVRENDER": {
+      "TITLE": "Previous renders",
+      "CLEAR": "Clear"
+    },   
     "PROGRESS_BAR": {
       "BATCH_UPSCAYL_IN_PROGRESS_TITLE": "Пакетное увеличение в процессе:",
       "IN_PROGRESS_TITLE": "Магия увеличения в процессе...",

--- a/renderer/locales/zh.json
+++ b/renderer/locales/zh.json
@@ -137,6 +137,10 @@
       "ZOOM_AMOUNT_TITLE": "缩放比例",
       "LENS_SIZE_TITLE": "透镜尺寸"
     },
+    "PREVRENDER": {
+      "TITLE": "Previous renders",
+      "CLEAR": "Clear"
+    },
     "PROGRESS_BAR": {
       "BATCH_UPSCAYL_IN_PROGRESS_TITLE": "批量阿普升图中",
       "IN_PROGRESS_TITLE": "稍等一下，升图魔法进行中",


### PR DESCRIPTION
![367324142-96d41334-0564-4b3f-89e9-d054b88ece12](https://github.com/user-attachments/assets/ed08d63e-689d-4793-8f64-1e58b4c145a5)

A new section "Previous renders" stores every rendering previously done for each image and displays it conveniently in the right pane.
You'd hover over each label to get a glimpse of the image rendered with said model for an easy compare between the different ones used so far

The selection is also memorized and stored in the local storage of the browser so it's not lost on every launch

_Side note_ : I did take into account the latest use of "translationAtom" values for easy translations

~~_Todo_ : Test it on Linux as well (tested on Windows only so far)~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new component to display and manage a history of previously rendered images.
  - Enhanced response structure for upscaling processes to provide more detailed information about output files.
  - Added localization support for "Previous renders" in multiple languages.

- **Bug Fixes**
  - Improved error message readability for long filenames.

- **Documentation**
  - Updated localization files to include new entries for "Previous renders" in various languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->