### PR TITLE
Support JFIF files which are basically JPGs anyways

### DIFF
--- a/electron/commands/select-file.ts
+++ b/electron/commands/select-file.ts
@@ -21,10 +21,12 @@ const selectFile = async () => {
           "png",
           "jpg",
           "jpeg",
+          "jfif",
           "webp",
           "PNG",
           "JPG",
           "JPEG",
+          "JFIF",
           "WEBP",
         ],
       },
@@ -50,10 +52,12 @@ const selectFile = async () => {
         file.endsWith(".png") ||
         file.endsWith(".jpg") ||
         file.endsWith(".jpeg") ||
+        file.endsWith(".jfif") ||
         file.endsWith(".webp") ||
         file.endsWith(".JPG") ||
         file.endsWith(".PNG") ||
         file.endsWith(".JPEG") ||
+        file.endsWith(".JFIF") ||
         file.endsWith(".WEBP")
       ) {
         isValid = true;

--- a/renderer/locales/en.json
+++ b/renderer/locales/en.json
@@ -194,7 +194,7 @@
     },
     "INVALID_IMAGE_ERROR": {
       "TITLE": "Invalid Image",
-      "DESCRIPTION": "Please select an image with a valid extension like PNG, JPG, JPEG, or WEBP.",
+      "DESCRIPTION": "Please select an image with a valid extension like PNG, JPG, JPEG, JFIF or WEBP.",
       "ADDITIONAL_DESCRIPTION": "Please drag and drop an image"
     },
     "NO_IMAGE_ERROR": {

--- a/renderer/locales/es.json
+++ b/renderer/locales/es.json
@@ -194,7 +194,7 @@
     },
     "INVALID_IMAGE_ERROR": {
       "TITLE": "Imagen inválida",
-      "DESCRIPTION": "Por favor, selecciona una imagen con una extensión válida como PNG, JPG, JPEG o WEBP.",
+      "DESCRIPTION": "Por favor, selecciona una imagen con una extensión válida como PNG, JPG, JPEG, JFIF o WEBP.",
       "ADDITIONAL_DESCRIPTION": "Por favor, arrastra y suelta una imagen"
     },
     "NO_IMAGE_ERROR": {

--- a/renderer/locales/fr.json
+++ b/renderer/locales/fr.json
@@ -194,7 +194,7 @@
     },
     "INVALID_IMAGE_ERROR": {
       "TITLE": "Image invalide",
-      "DESCRIPTION": "Veuillez sélectionner une image avec une extension valide comme PNG, JPG, JPEG ou WEBP.",
+      "DESCRIPTION": "Veuillez sélectionner une image avec une extension valide comme PNG, JPG, JPEG, JFIF ou WEBP.",
       "ADDITIONAL_DESCRIPTION": "Veuillez glisser-déposer une image"
     },
     "NO_IMAGE_ERROR": {

--- a/renderer/locales/ja.json
+++ b/renderer/locales/ja.json
@@ -194,7 +194,7 @@
     },
     "INVALID_IMAGE_ERROR": {
       "TITLE": "無効な画像",
-      "DESCRIPTION": "PNG、JPG、JPEG、またはWEBPなどの有効な拡張子を持つ画像を選択してください。",
+      "DESCRIPTION": "PNG、JPG、JPEG、JFIF、またはWEBPなどの有効な拡張子を持つ画像を選択してください。",
       "ADDITIONAL_DESCRIPTION": "画像をドラッグアンドドロップしてください"
     },
     "NO_IMAGE_ERROR": {

--- a/renderer/locales/locale_template
+++ b/renderer/locales/locale_template
@@ -192,7 +192,7 @@
     },
     "INVALID_IMAGE_ERROR": {
       "TITLE": "Invalid Image",
-      "DESCRIPTION": "Please select an image with a valid extension like PNG, JPG, JPEG, or WEBP.",
+      "DESCRIPTION": "Please select an image with a valid extension like PNG, JPG, JPEG, JFIF or WEBP.",
       "ADDITIONAL_DESCRIPTION": "Please drag and drop an image"
     },
     "NO_IMAGE_ERROR": {

--- a/renderer/locales/ru.json
+++ b/renderer/locales/ru.json
@@ -194,7 +194,7 @@
     },
     "INVALID_IMAGE_ERROR": {
       "TITLE": "Неверное изображение",
-      "DESCRIPTION": "Пожалуйста, выберите изображение с правильным расширением, таким как PNG, JPG, JPEG или WEBP.",
+      "DESCRIPTION": "Пожалуйста, выберите изображение с правильным расширением, таким как PNG, JPG, JPEG, JFIF или WEBP.",
       "ADDITIONAL_DESCRIPTION": "Пожалуйста, перетащите изображение"
     },
     "NO_IMAGE_ERROR": {

--- a/renderer/locales/zh.json
+++ b/renderer/locales/zh.json
@@ -194,7 +194,7 @@
     },
     "INVALID_IMAGE_ERROR": {
       "TITLE": "图片无效",
-      "DESCRIPTION": "请选择一个扩展名为 PNG、JPG、JPEG 或 WEBP 的有效图片",
+      "DESCRIPTION": "请选择一个扩展名为 PNG、JPG、JPEG、JFIF 或 WEBP 的有效图片",
       "ADDITIONAL_DESCRIPTION": "请拖放图片"
     },
     "NO_IMAGE_ERROR": {

--- a/renderer/pages/index.tsx
+++ b/renderer/pages/index.tsx
@@ -51,7 +51,7 @@ import getDirectoryFromPath from "@common/get-directory-from-path";
 import { translationAtom } from "@/atoms/translations-atom";
 
 const Home = () => {
-  const allowedFileTypes = ["png", "jpg", "jpeg", "webp"];
+  const allowedFileTypes = ["png", "jpg", "jpeg", "jfif", "webp"];
 
   const t = useAtomValue(translationAtom);
 


### PR DESCRIPTION
Just had to allow opening and validating the JFIF extension, since JFIF is a JPEG no "actual" code change was necessary. This should be a very low impact pull request. I've also updated the "invalid file error" messages in all locales to add JFIF to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the JFIF image format in file selection and error handling.
	- Updated the list of accepted file types to include JFIF in multiple languages.

- **Bug Fixes**
	- Enhanced error messages for invalid image formats to reflect JFIF as an acceptable extension across various locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->