### PR TITLE
Rename import filenames to fix main

### DIFF
--- a/renderer/components/sidebar/index.tsx
+++ b/renderer/components/sidebar/index.tsx
@@ -28,10 +28,10 @@ import {
 import { useToast } from "@/components/ui/use-toast";
 import UpscaylSteps from "./upscayl-tab/upscayl-steps";
 import SettingsTab from "./settings-tab";
-import Footer from "../footer";
+import Footer from "../Footer";
 import { NewsModal } from "../news-modal";
-import Tabs from "../tabs";
-import Header from "../header";
+import Tabs from "../Tabs";
+import Header from "../Header";
 import { ChevronLeftIcon } from "lucide-react";
 import { logAtom } from "@/atoms/log-atom";
 import { ELECTRON_COMMANDS } from "@common/electron-commands";


### PR DESCRIPTION
Commit 95843de was full send and broke main.
Simple rename imports to match filenames one dir up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted import statements for `Footer`, `Tabs`, and `Header` components to ensure proper casing, enhancing compatibility in case-sensitive environments.

- **Refactor**
	- Cleaned up the `Sidebar` component structure without altering existing functionality or user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->