### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,11 @@ on:
 # this is where the magic happens, each job happens in parallel btw
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -25,7 +25,7 @@ jobs:
           GH_TOKEN=${{ secrets.GITHUB_TOKEN }} npm run publish-linux-app
 
   macos:
-    runs-on: macos-11
+    runs-on: macos-13
     env:
       CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
       CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -35,8 +35,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PROVISION_PROFILE: ${{ secrets.PROVISION_PROFILE }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Install Modules and Publish build
@@ -51,9 +51,9 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 


### PR DESCRIPTION
- Bump `actions/checkout` and `actions/setup-node` to v4
  - Resolves deprecation warnings
  - `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3.5.0.`
  - ```The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files.```
- Bump Ubuntu runner to 24.04
- Bump macOS runner to 13
  - 11 is no longer available. See https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the CI/CD workflow environment to utilize newer operating system versions for improved compatibility and performance.
	- Upgraded the `actions/checkout` and `actions/setup-node` actions to their latest versions for enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->