### PR TITLE
Clarifying minimum requirements for GPU on the github wiki page

### DIFF
--- a/docs/Compatibility-List.md
+++ b/docs/Compatibility-List.md
@@ -10,11 +10,18 @@
 
 ## GPU
 
+Generally, Vulkan 1.3 conformance is required. This means, GPUs of the following architectures: 
+- Intel [Gen9](https://en.wikipedia.org/wiki/List_of_Intel_graphics_processing_units#Gen9) - Skylake (mostly 6th gen) on Windows, and Kaby Lake (mostly 7th gen) on Linux, or newer
+- NVidia Maxwell (mostly 9xx series) or newer 
+- AMD GCN4.0 (mostly Polaris and Arctic Islands/RX 4xx and RX 5xx series) or newer
+  
+  If you are unsure of your GPU's architecture, you can use [Techpowerup's GPU database](https://www.techpowerup.com/gpu-specs/) to search your model, and confirm what architecture it uses, and the Vulkan conformance.
+
 Working integrated GPUs:
 - Intel HD Graphics 620 (credit: [@Axe7bravo](https://github.com/upscayl/upscayl/issues/382))
 - Intel Iris Graphics (credit: [@arrhoegs](https://github.com/orgs/upscayl/discussions/571))
 - Most AMD Vega GPUs (credit: [@Yaki-0](https://github.com/upscayl/upscayl/issues/448) for Vega 8 Mobile, [@CloakTheLurker](https://github.com/upscayl/upscayl/issues/436) for Vega 10)
 
 All dedicated GPUs are assumed to work, except for the following that have been reported to be not working:
-- GTX 7xx series
-- GT 920M ? (see [comment](https://github.com/upscayl/upscayl/issues/401#issuecomment-1659604580))
+- GTX 7xx series (mostly Kepler chips)
+- GT 920M ? (see [comment](https://github.com/upscayl/upscayl/issues/401#issuecomment-1659604580), it's a Kepler chip, despite the model number being on the 900's instead of 700's)


### PR DESCRIPTION
After checking out the GPU compatibility page, it seems clear to me that what Upscayl requires from the GPU, is specifically Vulkan 1.3 compliance. This explains the known incompatibilities currently shown. GTX 7xx is mostly the Kepler architecture, which, can only do Vulkan 1.2, and the GT920M is a Kepler chip, despite the model number being on the 900's. Do not trust model numbers, especially on the Nvidia mobile chips. It also explains why most IGPUs won't work, as there is a very large number of Intel graphics generations that do not reach 1.3 conformance. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated GPU compatibility requirements with detailed Vulkan 1.3 conformance information
	- Clarified supported GPU architectures
	- Added reference to Techpowerup's GPU database for architecture identification
	- Expanded notes on non-working GPU series and specific chip details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->