### PR TITLE
fix: enforce Windows filename length limit check only on Win32 platform

### DIFF
--- a/electron/commands/image-upscayl.ts
+++ b/electron/commands/image-upscayl.ts
@@ -59,7 +59,7 @@ const imageUpscayl = async (event, payload: ImageUpscaylPayload) => {
   const isDefaultModel = model in MODELS;
 
   // Check if windows can write the new filename to the file system
-  if (outFile.length >= 255) {
+  if (process.platform === 'win32' && outFile.length >= 255) {
     logit("Filename too long for Windows.");
     mainWindow.webContents.send(
       ELECTRON_COMMANDS.UPSCAYL_ERROR,


### PR DESCRIPTION
This PR addresses an issue where the filename length check (`outFile.length >= 255`) was enforced globally, causing unnecessary errors on non-Windows systems.  

**Changes:**  
- Added a platform-specific check using `process.platform === 'win32'` to ensure the filename length validation **only applies to Windows**.  
  - Windows has a [MAX_PATH limit of 255 characters](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation), while other OSes (Linux/macOS) support longer filenames.  

**Technical Reference:**  
- Uses Node.js [`process.platform`](https://nodejs.org/api/process.html#processplatform) to detect the OS.  

**Impact:**  
- Prevents false-positive errors on Linux/macOS when filenames exceed 255 characters.  
- Maintains compatibility with Windows file system constraints.  

**Resolves:** #1167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated file name length validation so it only applies on Windows systems, reducing unnecessary error prompts on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->