### PR TITLE
fix: persist last used image format in "Save image as" setting

### DIFF
--- a/renderer/components/sidebar/settings-tab/index.tsx
+++ b/renderer/components/sidebar/settings-tab/index.tsx
@@ -64,7 +64,6 @@ function SettingsTab({
   // HANDLERS
   const setExportType = (format: ImageFormat) => {
     setSaveImageAs(format);
-    localStorage.setItem("saveImageAs", format);
   };
 
   const handleCompressionChange = (e) => {


### PR DESCRIPTION

This pull request addresses #1225, where the application did not remember the last selected image format in the "Save image as" setting.

### Summary of Changes

- **Removed redundant localStorage call:**
The line `localStorage.setItem("saveImageAs", format);` was removed from the `setExportType` handler in [`index.tsx`](https://github.com/upscayl/upscayl/compare/main...medinapdr:upscayl:fix/1225).
Since the state is already persisted by `atomWithStorage`, this manual call was unnecessary.

- **Why This Fixes the Issue**
By removing the redundant persistence call, the application now relies solely on `atomWithStorage` to save and restore the last selected image format. This ensures the user's choice is correctly remembered across sessions.

### References

Resolves #1225 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed persistent storage of the selected image export format, so changes to export type will no longer be saved across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->