### PR TITLE
Fix hidden output files in Unix-based systems

### DIFF
--- a/common/get-file-name.ts
+++ b/common/get-file-name.ts
@@ -1,5 +1,5 @@
 export default function getFilenameFromPath(path: string) {
   if (!path) return "";
   const separator = path.includes("/") ? "/" : "\\";
-  return path.split(separator).slice(-1)[0];
+  return path.split(separator).slice(-1)[0].replace(/^\.+/, '');
 }


### PR DESCRIPTION
Should fix #1201 where output files contain a leading dot and therefore are hidden in Unix-based systems, when the input was pasted from the clipboard (because the input name is prepended with a leading dot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filenames extracted from paths no longer include leading dots. Hidden files (e.g., .env, .gitignore) are now shown without the dot prefix.
  * Non-dot-prefixed filenames are unaffected.
  * Improves consistency for filename display and comparisons across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->