### PR TITLE
Docs external links new tab and logo issue in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ npm run publish-app
 
 <a href="https://www.buymeacoffee.com/fossisthefuture" target="_blank" rel="noopener noreferrer">
   <img src="https://user-images.githubusercontent.com/25067102/154570688-9e143f2b-fee3-4b05-a9d2-a7a3013b2b51.png" />
-<a/>
+</a>
 
 # ❤ Credits
 


### PR DESCRIPTION
upscayl readme.md key changes

changed all the links to open in a new tab by using target="_blank"

also an issue at line 110 the image sourced does not reflect on the readme.md when looked from outside - resolved it, changed it to standard donwload it on the mac app store image

did not make it jump to new page and kept the lines
 113 
137-140
further till 160 - 205
as it as it sends to the github page itself or the official website


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized external links in README to open in new tabs with secure attributes.
  * Replaced plain URLs with inline anchors for downloads, distributions, docs, donations, socials, sponsorship and store badges.
  * Converted credits and model references to external links.
  * Added a centered wrapper and made minor formatting and wording cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->