### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -9,9 +9,9 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
 
@@ -23,7 +23,7 @@ jobs:
       # Get the latest release
       - name: Get Latest Release
         id: get_latest_release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const latestRelease = await github.rest.repos.getLatestRelease({
@@ -43,7 +43,7 @@ jobs:
             dist/*.yml
 
       - name: Upload Windows Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: windows-build
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
   linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
 
@@ -38,8 +38,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PROVISION_PROFILE: ${{ secrets.PROVISION_PROFILE }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
       - name: Install Modules and Publish build
@@ -54,9 +54,9 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           operations-per-run: 100
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. If this is still happening, please reply to indicate so.'


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/stale` from `v9` to `v10` in `.github/workflows/stale.yml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/main.yml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/build-windows.yml`
- Updated `actions/setup-node` from `v3.5.0` to `v6` in `.github/workflows/main.yml`
- Updated `actions/github-script` from `v6` to `v8` in `.github/workflows/build-windows.yml`
- Updated `actions/setup-node` from `v3.5.0` to `v6` in `.github/workflows/build-windows.yml`
- Updated `actions/upload-artifact` from `v3` to `v6` in `.github/workflows/build-windows.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow versions across build pipelines for improved infrastructure maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->